### PR TITLE
Improved config using build system, send telemetry messages forever, improved docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .settings
 .project
 .cproject
+.vscode/
 
 build
 sdkconfig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # A MQTT Demo that Connects ESP device to Azure Cloud 
 
 # Table of Contents
+
 - [Introduction](#introduction)
 - [Preparation](#preparation)
 - [Configuring and Building](#configuring-and-building)
@@ -8,6 +9,7 @@
 - [Troubleshooting](#troubleshooting)
 
 ## Introduction
+
 <a name="Introduction"></a>
 
 Espressif offers a wide range of fully-certified Wi-Fi & BT modules powered by our own advanced SoCs. For more details, see [Espressif Modules](https://www.espressif.com/en/products/hardware/modules).
@@ -25,10 +27,12 @@ Main workflow:
 <a name="preparation"></a>
 
 ### 1. Hardware
+
 - An **ubuntu environment** should be set up to build your demo;
 - Any **[ESP device](https://www.espressif.com/en/products/hardware/modules)** can be used to run your demo.
 
 ### 2. Azure IoT Hub
+
 - [Get iothub connection string (primary key)](https://www.azure.cn/en-us/pricing/1rmb-trial-full/?form-type=identityauth) from the Azure IoT Hub, which will be used later. An example can be seen below:
 
 ```
@@ -37,6 +41,7 @@ HostName=yourname-ms-lot-hub.azure-devices.cn;SharedAccessKeyName=iothubowner;Sh
 - For step-by-step instructions, please click [here](doc/IoT_Suite.md).
 
 ### 3. iothub-explorer
+
 - Install [Node.js](https://nodejs.org/en/);  
 - Install [iothub-explorer](https://www.npmjs.com/package/iothub-explorer) with command line `npm install -g iothub-explorer`.
   - If failed, please check [here](http://thinglabs.io/workshop/esp8266/setup-azure-iot-hub/) for more information.
@@ -51,6 +56,7 @@ $ iothub-explorer -V
 After that, you should be able to use iothub-explorer to manage your iot-device.
 
 ### 4. Device Connection String
+
 - login with the **iothub connection string (primary key)** you got earlier with command lines;
 - create your device, and get a **device connection string**. An example can be seen:
 
@@ -61,12 +67,14 @@ After that, you should be able to use iothub-explorer to manage your iot-device.
 For detailed instruction, please click [Here](doc/iothub_explorer.md).
  
 ### 5. SDK
+
 - [AZURE-SDK](https://github.com/espressif/esp-azure) can be implemented to connect your ESP devices to Azure, using MQTT protocol.
 - Espressif SDK
   - For ESP32 platform: [ESP-IDF](https://github.com/espressif/esp-idf)  
   - For ESP8266 platform: [ESP8266_RTOS_SDK](https://github.com/espressif/ESP8266_RTOS_SDK)
 
 ### 6. Compiler
+
 - For ESP32 platform: [Here](https://github.com/espressif/esp-idf/blob/master/README.md)
 - For ESP8266 platform: [Here](https://github.com/espressif/ESP8266_RTOS_SDK/blob/master/README.md)
 
@@ -78,31 +86,38 @@ For detailed instruction, please click [Here](doc/iothub_explorer.md).
 
 This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for its dependancies. To successfully clone these other repositories, after cloning this repo, use the following command in the root:
 
-```
+``` bash
 git submodule update --init --recursive
 ```
 
-### 2. Updating variables
-- Replace the `connectionString` variable with your device connection string in [esp-azure/main/iothub_client_sample_mqtt.c](https://github.com/espressif/esp-azure/blob/master/main/iothub_client_sample_mqtt.c).
+### 2. Configuring your Azure IOT Hub Device Connection String, Wi-Fi and serial port
 
-```
-static const char* connectionString = '[azure connection string]';
-```
-- The azure connection string contains Hostname, DeviceId, and SharedAccessKey in the format:
-
-```
-"HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
-```
-
-### 3. Configuring your Wi-Fi and serial port
-- Go to `make menuconfig` -> `Example configuration` to  configure your Wi-Fi SSID and Password; 
+- Go to `make menuconfig` -> `Example configuration` to configure your Azure IOT Hub Device Connection String, Wi-Fi SSID and Password; 
 - Go to `make menuconfig` -> `Serial flasher config` to configure you serial port.
 
-### 4. Building your demo and flash to ESP device with `$make flash`.
+### 3. Building your demo and flash to ESP device with `$make flash`.
+
 If failed, please:
+
 - make sure your ESP device had connected to PC with serial port;
 - make sure you have selected the corrected serial port;
   - command `> sudo usermod -a -G dialout $USER` can also be used.
+
+To monitor the device output while running, run 
+
+``` bash
+make monitor
+```
+
+To exit the monitor, hit Control-]
+
+You can also run the build and monitor in onte step and run with multiple compiler threads:
+
+``` bash
+make -j4 flash monitor
+```
+
+This will build with four concurrent build processes to take advantage of more cores on your workstation.
 
 ## Checking Result
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Main workflow:
 ## Preparation 
 
 <a name="preparation"></a>
+
 ### 1. Hardware
 - An **ubuntu environment** should be set up to build your demo;
 - Any **[ESP device](https://www.espressif.com/en/products/hardware/modules)** can be used to run your demo.
@@ -73,7 +74,15 @@ For detailed instruction, please click [Here](doc/iothub_explorer.md).
 
 <a name="Configuring_and_Building"></a>
 
-### 1. Updating variables
+### 1. Cloning Git submodules
+
+This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for its dependancies. To successfully clone these other repositories, after cloning this repo, use the following command in the root:
+
+```
+git submodule update --init --recursive
+```
+
+### 2. Updating variables
 - Replace the `connectionString` variable with your device connection string in [esp-azure/main/iothub_client_sample_mqtt.c](https://github.com/espressif/esp-azure/blob/master/main/iothub_client_sample_mqtt.c).
 
 ```
@@ -85,11 +94,11 @@ static const char* connectionString = '[azure connection string]';
 "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
 ```
 
-### 2. Configuring your Wi-Fi and serial port
+### 3. Configuring your Wi-Fi and serial port
 - Go to `make menuconfig` -> `Example configuration` to  configure your Wi-Fi SSID and Password; 
 - Go to `make menuconfig` -> `Serial flasher config` to configure you serial port.
 
-### 3. Building your demo and flash to ESP device with `$make flash`.
+### 4. Building your demo and flash to ESP device with `$make flash`.
 If failed, please:
 - make sure your ESP device had connected to PC with serial port;
 - make sure you have selected the corrected serial port;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -14,4 +14,15 @@ config WIFI_PASSWORD
 
 		Can be left blank if the network has no security set.
 
+config IOTHUB_CONNECTION_STRING
+    string "IOT Hub Device Connection String"
+	default "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
+	help
+		String containing Hostname, Device Id & Device Key in the format:
+		
+		HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>
+		HostName=<host_name>;DeviceId=<device_id>;SharedAccessSignature=<device_sas_token>
+
+		You can get this from the iothub-explorer CLI or the Azure Portal
+
 endmenu


### PR DESCRIPTION
I added some changes that will make this code an easier starting point for developers:

- Improved README with clear directions on how to clone the subrepositories in one command
- Moved the config for the Azure IOT Hub key to the menu-based config UI (where the wifi settings already are)
- Made the device keep sending data every 5 seconds instead of sending a few messages then stopping (this is more common in IOT scenarios)