### PR TITLE
cap rcv_bytes loop

### DIFF
--- a/port/src/tlsio_esp_tls.c
+++ b/port/src/tlsio_esp_tls.c
@@ -394,7 +394,7 @@ static int dowork_read(TLS_IO_INSTANCE* tls_io_instance)
     // Putting this buffer in a small function also allows it to exist on the stack
     // rather than adding to heap fragmentation.
     unsigned char buffer[TLSIO_RECEIVE_BUFFER_SIZE];
-    int rcv_bytes;
+    int rcv_bytes = 0;
     int rcv_count = 0;
     
     if (tls_io_instance->tlsio_state == TLSIO_STATE_OPEN)

--- a/port/src/tlsio_esp_tls.c
+++ b/port/src/tlsio_esp_tls.c
@@ -36,6 +36,7 @@ typedef struct
 // to minimize memory consumption.
 #define TLSIO_RECEIVE_BUFFER_SIZE 64
 
+#define MAX_RCV_COUNT 5
 
 typedef enum TLSIO_STATE_TAG
 {
@@ -393,12 +394,13 @@ static int dowork_read(TLS_IO_INSTANCE* tls_io_instance)
     // Putting this buffer in a small function also allows it to exist on the stack
     // rather than adding to heap fragmentation.
     unsigned char buffer[TLSIO_RECEIVE_BUFFER_SIZE];
-    int rcv_bytes = 0;
-
+    int rcv_bytes;
+    int rcv_count = 0;
+    
     if (tls_io_instance->tlsio_state == TLSIO_STATE_OPEN)
     {
         rcv_bytes = esp_tls_conn_read(tls_io_instance->esp_tls_handle, buffer, sizeof(buffer));
-        while (rcv_bytes > 0)
+        while (rcv_bytes > 0 && rcv_count++ < MAX_RCV_COUNT)
         {
             // tls_io_instance->on_bytes_received was already checked for NULL
             // in the call to tlsio_esp_tls_open_async


### PR DESCRIPTION
In this implementation of the TLS layer for the dowork_read, there is a potential for the rcv_bytes loop to go on continuously without breaking. As long as data continues to stream into the socket, the esp_tls_conn_read will return a non-zero number for rcv_bytes. To prevent this from occurring and allowing other processes such as a watchdog to execute, we set a cap of 5 iterations through the loop, at which point we will break and continue on to other tasks before the next dowork call.