### PR TITLE
Use esp-azure as an esp-idf project component (CA-42)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Component Makefile
 #
 
-set (AZURE_IOT_SDK "${CMAKE_CURRENT_LIST_DIR}/../azure-iot-sdk-c")
+set (AZURE_IOT_SDK "${CMAKE_CURRENT_LIST_DIR}/azure-iot-sdk-c")
 
 set (COMPONENT_ADD_INCLUDEDIRS
-    "inc"
+    "port/inc"
     "${AZURE_IOT_SDK}/certs"
 	"${AZURE_IOT_SDK}/c-utility/inc"
 	"${AZURE_IOT_SDK}/c-utility/pal/inc"
@@ -22,9 +22,9 @@ set (COMPONENT_ADD_INCLUDEDIRS
 	)
 
 set (COMPONENT_SRCS
-	"src/agenttime_esp.c"
-	"src/platform_esp.c"
-	"src/tlsio_esp_tls.c"
+	"port/src/agenttime_esp.c"
+	"port/src/platform_esp.c"
+	"port/src/tlsio_esp_tls.c"
 	"${AZURE_IOT_SDK}/certs/certs.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/freertos/lock.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/dns_async.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set (COMPONENT_ADD_INCLUDEDIRS
 	"${AZURE_IOT_SDK}/umqtt/inc"
 	"${AZURE_IOT_SDK}/umqtt/inc/azure_umqtt_c"
 	"${AZURE_IOT_SDK}/deps/parson"
+	"${AZURE_IOT_SDK}/deps/azure-macro-utils-c/inc"
+	"${AZURE_IOT_SDK}/deps/umock-c/inc"
 	"${AZURE_IOT_SDK}/provisioning_client/inc"
 	"${AZURE_IOT_SDK}/provisioning_client/adapters"
 	"${AZURE_IOT_SDK}/provisioning_client/deps/utpm/inc"
@@ -27,7 +29,7 @@ set (COMPONENT_SRCS
 	"port/src/tlsio_esp_tls.c"
 	"${AZURE_IOT_SDK}/certs/certs.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/freertos/lock.c"
-	"${AZURE_IOT_SDK}/c-utility/pal/dns_async.c"
+	"${AZURE_IOT_SDK}/c-utility/pal/agenttime.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/socket_async.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/freertos/threadapi.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/freertos/tickcounter.c"
@@ -60,7 +62,9 @@ set (COMPONENT_SRCS
 	"${AZURE_IOT_SDK}/c-utility/src/usha.c"
 	"${AZURE_IOT_SDK}/c-utility/src/vector.c"
 	"${AZURE_IOT_SDK}/c-utility/src/xio.c"
-	"${AZURE_IOT_SDK}/c-utility/src/base64.c"
+	"${AZURE_IOT_SDK}/c-utility/src/azure_base32.c"
+	"${AZURE_IOT_SDK}/c-utility/src/azure_base64.c"
+	"${AZURE_IOT_SDK}/c-utility/src/http_proxy_io.c"
 	"${AZURE_IOT_SDK}/iothub_client/src/iothub_device_client_ll.c"
 	"${AZURE_IOT_SDK}/iothub_client/src/iothub_client_ll.c"
 	"${AZURE_IOT_SDK}/iothub_client/src/iothub_client_core_ll.c"
@@ -107,8 +111,6 @@ set (COMPONENT_SRCS
 	"${AZURE_IOT_SDK}/provisioning_client/deps/utpm/src/Memory.c"
 	"${AZURE_IOT_SDK}/provisioning_client/deps/utpm/src/tpm_socket_comm.c"
 	"${AZURE_IOT_SDK}/iothub_client/src/iothub.c"
-	"${AZURE_IOT_SDK}/c-utility/src/http_proxy_io.c"
-	"${AZURE_IOT_SDK}/c-utility/src/base32.c"
 	)
 
 if (CONFIG_DEVICE_COMMON_NAME)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+Before using any example, please copy them in a separate folder.
+Then, create a subfolder called `components` and copy (or link) `esp-azure` inside of that subfolder.
+
+`esp-azure` can be also referenced as a git submodule.

--- a/examples/iothub_client_sample_mqtt/CMakeLists.txt
+++ b/examples/iothub_client_sample_mqtt/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(iothub_client_sample_mqtt)

--- a/examples/iothub_devicetwin_samples_and_methods/CMakeLists.txt
+++ b/examples/iothub_devicetwin_samples_and_methods/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(iothub_devicetwin_samples_and_methods)

--- a/examples/prov_dev_client_ll_sample/CMakeLists.txt
+++ b/examples/prov_dev_client_ll_sample/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(prov_dev_client_ll_sample)

--- a/port/inc/tlsio_pal.h
+++ b/port/inc/tlsio_pal.h
@@ -5,7 +5,7 @@
 #define TLSIO_PAL_H
 
 #include "azure_c_shared_utility/tlsio.h"
-#include "azure_c_shared_utility/umock_c_prod.h"
+#include "umock_c/umock_c_prod.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/port/src/agenttime_esp.c
+++ b/port/src/agenttime_esp.c
@@ -8,7 +8,7 @@
 #include "freertos/event_groups.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
-#include "esp_event_loop.h"
+#include "esp_event.h"
 #include "esp_log.h"
 #include "esp_attr.h"
 
@@ -56,25 +56,4 @@ time_t sntp_get_current_timestamp()
 	}
 	localtime_r(&now, &timeinfo);
 	return now;
-}
-
-time_t get_time(time_t* currentTime)
-{
-    return sntp_get_current_timestamp();
-
-}
-
-double get_difftime(time_t stopTime, time_t startTime)
-{	
-    return (double)stopTime - (double)startTime;
-}
-
-struct tm* get_gmtime(time_t* currentTime)
-{
-    return NULL;
-}
-
-char* get_ctime(time_t* timeToGet)
-{
-    return NULL;
 }

--- a/port/src/platform_esp.c
+++ b/port/src/platform_esp.c
@@ -46,7 +46,7 @@ void platform_deinit(void)
       sntp_stop();
 }
 
-STRING_HANDLE platform_get_platform_info(void)
+STRING_HANDLE platform_get_platform_info(PLATFORM_INFO_OPTION options)
 {
     // Expected format: "(<runtime name>; <operating system name>; <platform>)"
 

--- a/port/src/tlsio_esp_tls.c
+++ b/port/src/tlsio_esp_tls.c
@@ -264,14 +264,14 @@ static int tlsio_esp_tls_open_async(CONCRETE_IO_HANDLE tls_io,
     {
         /* Codes_SRS_TLSIO_30_031: [ If the on_io_open_complete parameter is NULL, tlsio_open shall log an error and return FAILURE. ]*/
         LogError("Required parameter on_io_open_complete is NULL");
-        result = __FAILURE__;
+        result = MU_FAILURE;
     }
     else
     {
         if (tls_io == NULL)
         {
             /* Codes_SRS_TLSIO_30_030: [ If the tlsio_handle parameter is NULL, tlsio_open shall log an error and return FAILURE. ]*/
-            result = __FAILURE__;
+            result = MU_FAILURE;
             LogError("NULL tlsio");
         }
         else
@@ -280,7 +280,7 @@ static int tlsio_esp_tls_open_async(CONCRETE_IO_HANDLE tls_io,
             {
                 /* Codes_SRS_TLSIO_30_032: [ If the on_bytes_received parameter is NULL, tlsio_open shall log an error and return FAILURE. ]*/
                 LogError("Required parameter on_bytes_received is NULL");
-                result = __FAILURE__;
+                result = MU_FAILURE;
             }
             else
             {
@@ -288,7 +288,7 @@ static int tlsio_esp_tls_open_async(CONCRETE_IO_HANDLE tls_io,
                 {
                     /* Codes_SRS_TLSIO_30_033: [ If the on_io_error parameter is NULL, tlsio_open shall log an error and return FAILURE. ]*/
                     LogError("Required parameter on_io_error is NULL");
-                    result = __FAILURE__;
+                    result = MU_FAILURE;
                 }
                 else
                 {
@@ -298,7 +298,7 @@ static int tlsio_esp_tls_open_async(CONCRETE_IO_HANDLE tls_io,
                     {
                         /* Codes_SRS_TLSIO_30_037: [ If the adapter is in any state other than TLSIO_STATE_EXT_CLOSED when tlsio_open  is called, it shall log an error, and return FAILURE. ]*/
                         LogError("Invalid tlsio_state. Expected state is TLSIO_STATE_CLOSED.");
-                        result = __FAILURE__;
+                        result = MU_FAILURE;
                     }
                     else
                     {
@@ -346,7 +346,7 @@ static int tlsio_esp_tls_close_async(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMP
     {
         /* Codes_SRS_TLSIO_30_050: [ If the tlsio_handle parameter is NULL, tlsio_esp_tls_close_async shall log an error and return FAILURE. ]*/
         LogError("NULL tlsio");
-        result = __FAILURE__;
+        result = MU_FAILURE;
     }
     else
     {
@@ -354,7 +354,7 @@ static int tlsio_esp_tls_close_async(CONCRETE_IO_HANDLE tls_io, ON_IO_CLOSE_COMP
         {
             /* Codes_SRS_TLSIO_30_055: [ If the on_io_close_complete parameter is NULL, tlsio_esp_tls_close_async shall log an error and return FAILURE. ]*/
             LogError("NULL on_io_close_complete");
-            result = __FAILURE__;
+            result = MU_FAILURE;
         }
         else
         {
@@ -515,7 +515,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
     if (on_send_complete == NULL)
     {
         /* Codes_SRS_TLSIO_30_062: [ If the on_send_complete is NULL, tlsio_esp_tls_send_async shall log the error and return FAILURE. ]*/
-        result = __FAILURE__;
+        result = MU_FAILURE;
         LogError("NULL on_send_complete");
     }
     else
@@ -523,7 +523,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
         if (tls_io == NULL)
         {
             /* Codes_SRS_TLSIO_30_060: [ If the tlsio_handle parameter is NULL, tlsio_esp_tls_send_async shall log an error and return FAILURE. ]*/
-            result = __FAILURE__;
+            result = MU_FAILURE;
             LogError("NULL tlsio");
         }
         else
@@ -531,7 +531,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
             if (buffer == NULL)
             {
                 /* Codes_SRS_TLSIO_30_061: [ If the buffer is NULL, tlsio_esp_tls_send_async shall log the error and return FAILURE. ]*/
-                result = __FAILURE__;
+                result = MU_FAILURE;
                 LogError("NULL buffer");
             }
             else
@@ -539,7 +539,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
                 if (size == 0)
                 {
                     /* Codes_SRS_TLSIO_30_067: [ If the  size  is 0,  tlsio_send  shall log the error and return FAILURE. ]*/
-                    result = __FAILURE__;
+                    result = MU_FAILURE;
                     LogError("0 size");
                 }
                 else
@@ -547,7 +547,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
                     TLS_IO_INSTANCE* tls_io_instance = (TLS_IO_INSTANCE*)tls_io;
                     if (tls_io_instance->tlsio_state != TLSIO_STATE_OPEN)
                     {
-                        result = __FAILURE__;
+                        result = MU_FAILURE;
                         LogError("tlsio_esp_tls_send_async without a prior successful open");
                     }
                     else
@@ -556,7 +556,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
                         if (pending_transmission == NULL)
                         {
                             /* Codes_SRS_TLSIO_30_064: [ If the supplied message cannot be enqueued for transmission, tlsio_esp_tls_send shall log an error and return FAILURE. ]*/
-                            result = __FAILURE__;
+                            result = MU_FAILURE;
                             LogError("malloc failed");
                         }
                         else
@@ -569,7 +569,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
                                 /* Codes_SRS_TLSIO_30_064: [ If the supplied message cannot be enqueued for transmission, tlsio_esp_tls_send shall log an error and return FAILURE. ]*/
                                 LogError("malloc failed");
                                 free(pending_transmission);
-                                result = __FAILURE__;
+                                result = MU_FAILURE;
                             }
                             else
                             {
@@ -585,7 +585,7 @@ static int tlsio_esp_tls_send_async(CONCRETE_IO_HANDLE tls_io, const void* buffe
                                     LogError("Unable to add socket to pending list.");
                                     free(pending_transmission->bytes);
                                     free(pending_transmission);
-                                    result = __FAILURE__;
+                                    result = MU_FAILURE;
                                 }
                                 else
                                 {
@@ -612,7 +612,7 @@ static int tlsio_esp_tls_setoption(CONCRETE_IO_HANDLE tls_io, const char* option
     if (tls_io_instance == NULL)
     {
         LogError("NULL tlsio");
-        result = __FAILURE__;
+        result = MU_FAILURE;
     }
     else
     {
@@ -623,7 +623,7 @@ static int tlsio_esp_tls_setoption(CONCRETE_IO_HANDLE tls_io, const char* option
         if (options_result != TLSIO_OPTIONS_RESULT_SUCCESS)
         {
             LogError("Failed tlsio_options_set");
-            result = __FAILURE__;
+            result = MU_FAILURE;
         }
         else
         {


### PR DESCRIPTION
Hi,
I tried to include `esp-azure` as a component (cloning it in `components` folder of a project). Unfortunately, the build failed. You need to explicitly set the extra component path in `CMakeLists.txt`.

With these patches, it is now possible to just download it in `components` and have it automatically linked and built.