### PR TITLE
Use esp-azure as an esp-idf project component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@
 # Component Makefile
 #
 
-set (AZURE_IOT_SDK "${CMAKE_CURRENT_LIST_DIR}/../azure-iot-sdk-c")
+set (AZURE_IOT_SDK "${CMAKE_CURRENT_LIST_DIR}/azure-iot-sdk-c")
 
 set (COMPONENT_ADD_INCLUDEDIRS
-    "inc"
+    "port/inc"
     "${AZURE_IOT_SDK}/certs"
 	"${AZURE_IOT_SDK}/c-utility/inc"
 	"${AZURE_IOT_SDK}/c-utility/pal/inc"
@@ -22,9 +22,9 @@ set (COMPONENT_ADD_INCLUDEDIRS
 	)
 
 set (COMPONENT_SRCS
-	"src/agenttime_esp.c"
-	"src/platform_esp.c"
-	"src/tlsio_esp_tls.c"
+	"port/src/agenttime_esp.c"
+	"port/src/platform_esp.c"
+	"port/src/tlsio_esp_tls.c"
 	"${AZURE_IOT_SDK}/certs/certs.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/freertos/lock.c"
 	"${AZURE_IOT_SDK}/c-utility/pal/dns_async.c"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+Before using any example, please copy them in a separate folder.
+Then, create a subfolder called `components` and copy (or link) `esp-azure` inside of that subfolder.
+
+`esp-azure` can be also referenced as a git submodule.

--- a/examples/iothub_client_sample_mqtt/CMakeLists.txt
+++ b/examples/iothub_client_sample_mqtt/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(iothub_client_sample_mqtt)

--- a/examples/iothub_devicetwin_samples_and_methods/CMakeLists.txt
+++ b/examples/iothub_devicetwin_samples_and_methods/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(iothub_devicetwin_samples_and_methods)

--- a/examples/prov_dev_client_ll_sample/CMakeLists.txt
+++ b/examples/prov_dev_client_ll_sample/CMakeLists.txt
@@ -3,5 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set (EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../../../port")
 project(prov_dev_client_ll_sample)


### PR DESCRIPTION
Hi,
I tried to include `esp-azure` as a component (cloning it in `components` folder of a project). Unfortunately, the build failed. You need to explicitly set the extra component path in `CMakeLists.txt`.

With these patches, it is now possible to just download it in `components` and have it automatically linked and built.