### PR TITLE
Update top readme for newer libraries (CA-177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 - [Monitoring Results](#monitoring)
 - [Troubleshooting](#troubleshooting)
 
+## 2021 Update
+
+<a name="2021 update"></a>
+
+Since this library has been published, Microsoft has created newer versions of the Azure SDK for usage with the Espressif ESP32. This new library is better suited for microcontrollers, great for composition with your own network stack and officially supported by Microsoft. 
+
+The first one, [Azure IoT middleware for FreeRTOS](https://github.com/Azure/azure-iot-middleware-freertos), is based on ESP-IDF and FreeRTOS and it has [samples](https://github.com/Azure-Samples/iot-middleware-freertos-samples) for IoT Hub and IoT Central using the device provisioning service (DPS).
+
+The second one is based on [Azure IoT for C library for Arduino](https://github.com/Azure/azure-sdk-for-c-arduino) and also has samples for IoT Hub. 
+
+If you can, **avoid using this library for any new projects**.  
+
 ## Introduction
 
 <a name="introduction"></a>


### PR DESCRIPTION
Adding a comment at the top of the main readme referring to the newer libraries officially released by Microsoft, which should replace this sample (based on the previous version of the C SDK).